### PR TITLE
Potential fix for code scanning alert no. 35: Accepting unknown SSH host keys when using Paramiko

### DIFF
--- a/pacli/web/ssh_handler.py
+++ b/pacli/web/ssh_handler.py
@@ -1,6 +1,7 @@
 """SSH connection handler for web-based terminal access."""
 
 import re
+import os
 import paramiko  # type: ignore[import-untyped]
 import threading
 import queue
@@ -53,8 +54,12 @@ class SSHTerminal:
         """Establish SSH connection."""
         try:
             self.client = paramiko.SSHClient()
-            # nosec B507
-            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())  # nosec
+            self.client.load_system_host_keys()
+            try:
+                self.client.load_host_keys(os.path.expanduser("~/.ssh/known_hosts"))
+            except OSError:
+                pass
+            self.client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
             connect_kwargs = {
                 "hostname": self.hostname,


### PR DESCRIPTION
Potential fix for [https://github.com/imShakil/pacli/security/code-scanning/35](https://github.com/imShakil/pacli/security/code-scanning/35)

Use strict host key verification instead of auto-acceptance.

Best fix (without changing intended SSH functionality beyond security hardening):
1. In `pacli/web/ssh_handler.py` inside `SSHTerminal.connect`, remove `AutoAddPolicy`.
2. Load system/user known host keys with:
   - `self.client.load_system_host_keys()`
   - `self.client.load_host_keys(...)` for `~/.ssh/known_hosts` (best-effort)
3. Set `RejectPolicy` explicitly with `self.client.set_missing_host_key_policy(paramiko.RejectPolicy())`.

This preserves normal authentication behavior (password/key/agent) while preventing first-seen unknown hosts from being silently trusted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
