### PR TITLE
Potential fix for code scanning alert no. 34: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/pacli/store.py
+++ b/pacli/store.py
@@ -5,6 +5,7 @@ import base64
 import sqlite3
 import threading
 import hashlib
+import hmac
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes
@@ -237,12 +238,50 @@ class SecretStore:
             )
         return results
 
+    PBKDF2_ITERATIONS = 310000
+    PBKDF2_SALT_BYTES = 16
+
+    def _hash_password_pbkdf2(self, password: str, salt: bytes = None) -> str:
+        if salt is None:
+            salt = os.urandom(self.PBKDF2_SALT_BYTES)
+        dk = hashlib.pbkdf2_hmac(
+            "sha256",
+            password.encode(),
+            salt,
+            self.PBKDF2_ITERATIONS,
+        )
+        salt_b64 = base64.b64encode(salt).decode("utf-8")
+        dk_b64 = base64.b64encode(dk).decode("utf-8")
+        return f"pbkdf2_sha256${self.PBKDF2_ITERATIONS}${salt_b64}${dk_b64}"
+
+    def _verify_password_pbkdf2(self, password: str, stored: str) -> bool:
+        try:
+            scheme, iter_str, salt_b64, expected_b64 = stored.split("$", 3)
+            if scheme != "pbkdf2_sha256":
+                return False
+            iterations = int(iter_str)
+            salt = base64.b64decode(salt_b64.encode("utf-8"))
+            expected = base64.b64decode(expected_b64.encode("utf-8"))
+            actual = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, iterations)
+            return hmac.compare_digest(actual, expected)
+        except Exception:
+            return False
+
     def verify_master_password(self, password):
         try:
             if os.path.exists(PASSWORD_HASH_PATH):
                 with open(PASSWORD_HASH_PATH, "r") as f:
                     stored_hash = f.read().strip()
-                return hashlib.sha256(password.encode()).hexdigest() == stored_hash
+
+                if stored_hash.startswith("pbkdf2_sha256$"):
+                    return self._verify_password_pbkdf2(password, stored_hash)
+
+                # Legacy fallback: support old SHA-256 hashes and transparently upgrade.
+                legacy_ok = hashlib.sha256(password.encode()).hexdigest() == stored_hash
+                if legacy_ok:
+                    with open(PASSWORD_HASH_PATH, "w") as f:
+                        f.write(self._hash_password_pbkdf2(password))
+                return legacy_ok
             # Fallback: attempt decryption
             salt = get_salt()
             test_fernet = self._derive_fernet(password, salt)

--- a/pacli/store.py
+++ b/pacli/store.py
@@ -280,7 +280,7 @@ class SecretStore:
         dk_b64 = base64.b64encode(dk).decode("utf-8")
         return f"legacy_pbkdf2_sha256${self.PBKDF2_ITERATIONS}${salt_b64}${dk_b64}"
 
-    def _verify_legacy_sha256_with_pbkdf2(self, password: str, stored: str) -> bool:
+    def _verify_legacy_sha256_with_pbkdf2(self, legacy_sha256_hex: str, stored: str) -> bool:
         try:
             scheme, iter_str, salt_b64, expected_b64 = stored.split("$", 3)
             if scheme != "legacy_pbkdf2_sha256":
@@ -288,8 +288,7 @@ class SecretStore:
             iterations = int(iter_str)
             salt = base64.b64decode(salt_b64.encode("utf-8"))
             expected = base64.b64decode(expected_b64.encode("utf-8"))
-            legacy_actual = hashlib.sha256(password.encode()).hexdigest().encode("utf-8")
-            actual = hashlib.pbkdf2_hmac("sha256", legacy_actual, salt, iterations)
+            actual = hashlib.pbkdf2_hmac("sha256", legacy_sha256_hex.encode("utf-8"), salt, iterations)
             return hmac.compare_digest(actual, expected)
         except Exception:
             return False
@@ -306,15 +305,13 @@ class SecretStore:
                 # Legacy fallback: support old SHA-256 hashes and transparently upgrade.
                 legacy_ok = False
 
+                legacy_sha256 = hashlib.sha256(password.encode()).hexdigest()
+
                 if stored_hash.startswith("legacy_pbkdf2_sha256$"):
-                    legacy_ok = self._verify_legacy_sha256_with_pbkdf2(password, stored_hash)
+                    legacy_ok = self._verify_legacy_sha256_with_pbkdf2(legacy_sha256, stored_hash)
                 else:
                     # One-time migration for existing raw SHA-256 legacy values.
-                    legacy_sha256 = hashlib.sha256(password.encode()).hexdigest()
-                    wrapped = self._hash_legacy_sha256_with_pbkdf2(legacy_sha256)
-                    with open(PASSWORD_HASH_PATH, "w") as f:
-                        f.write(wrapped)
-                    legacy_ok = self._verify_legacy_sha256_with_pbkdf2(password, wrapped)
+                    legacy_ok = hmac.compare_digest(stored_hash, legacy_sha256)
 
                 if legacy_ok:
                     with open(PASSWORD_HASH_PATH, "w") as f:

--- a/pacli/store.py
+++ b/pacli/store.py
@@ -267,6 +267,33 @@ class SecretStore:
         except Exception:
             return False
 
+    def _hash_legacy_sha256_with_pbkdf2(self, legacy_sha256_hex: str, salt: bytes = None) -> str:
+        if salt is None:
+            salt = os.urandom(self.PBKDF2_SALT_BYTES)
+        dk = hashlib.pbkdf2_hmac(
+            "sha256",
+            legacy_sha256_hex.encode("utf-8"),
+            salt,
+            self.PBKDF2_ITERATIONS,
+        )
+        salt_b64 = base64.b64encode(salt).decode("utf-8")
+        dk_b64 = base64.b64encode(dk).decode("utf-8")
+        return f"legacy_pbkdf2_sha256${self.PBKDF2_ITERATIONS}${salt_b64}${dk_b64}"
+
+    def _verify_legacy_sha256_with_pbkdf2(self, password: str, stored: str) -> bool:
+        try:
+            scheme, iter_str, salt_b64, expected_b64 = stored.split("$", 3)
+            if scheme != "legacy_pbkdf2_sha256":
+                return False
+            iterations = int(iter_str)
+            salt = base64.b64decode(salt_b64.encode("utf-8"))
+            expected = base64.b64decode(expected_b64.encode("utf-8"))
+            legacy_actual = hashlib.sha256(password.encode()).hexdigest().encode("utf-8")
+            actual = hashlib.pbkdf2_hmac("sha256", legacy_actual, salt, iterations)
+            return hmac.compare_digest(actual, expected)
+        except Exception:
+            return False
+
     def verify_master_password(self, password):
         try:
             if os.path.exists(PASSWORD_HASH_PATH):
@@ -277,7 +304,18 @@ class SecretStore:
                     return self._verify_password_pbkdf2(password, stored_hash)
 
                 # Legacy fallback: support old SHA-256 hashes and transparently upgrade.
-                legacy_ok = hashlib.sha256(password.encode()).hexdigest() == stored_hash
+                legacy_ok = False
+
+                if stored_hash.startswith("legacy_pbkdf2_sha256$"):
+                    legacy_ok = self._verify_legacy_sha256_with_pbkdf2(password, stored_hash)
+                else:
+                    # One-time migration for existing raw SHA-256 legacy values.
+                    legacy_sha256 = hashlib.sha256(password.encode()).hexdigest()
+                    wrapped = self._hash_legacy_sha256_with_pbkdf2(legacy_sha256)
+                    with open(PASSWORD_HASH_PATH, "w") as f:
+                        f.write(wrapped)
+                    legacy_ok = self._verify_legacy_sha256_with_pbkdf2(password, wrapped)
+
                 if legacy_ok:
                     with open(PASSWORD_HASH_PATH, "w") as f:
                         f.write(self._hash_password_pbkdf2(password))


### PR DESCRIPTION
Potential fix for [https://github.com/imShakil/pacli/security/code-scanning/34](https://github.com/imShakil/pacli/security/code-scanning/34)

Use a dedicated password hashing function that is intentionally expensive and includes a salt/work factor. Since we should avoid adding new dependencies and only edit shown code, the best fit is Python stdlib `hashlib.pbkdf2_hmac` with a per-password random salt and high iteration count, storing a structured value like `pbkdf2_sha256$<iterations>$<salt_b64>$<hash_b64>`.

In `pacli/store.py`, replace the SHA-256 comparison in `verify_master_password` (line region around 240–246) with parser+verifier logic for PBKDF2 records using constant-time comparison (`hmac.compare_digest`). Keep backward compatibility by supporting legacy SHA-256 entries: if the stored file is not PBKDF2 format, verify using old SHA-256 once; if it matches, transparently upgrade the stored hash to PBKDF2 format. This preserves existing functionality while remediating the weakness for all future checks. Add only stdlib imports needed (`hmac`) and helper methods inside the same file/class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
